### PR TITLE
feat(dashboard): add archived indicator to order page

### DIFF
--- a/app/dashboard/[id]/page.tsx
+++ b/app/dashboard/[id]/page.tsx
@@ -22,6 +22,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/formTa
 import { Separator } from "@/components/ui/separator";
 import { Typography } from "@/components/ui/Typography";
 import { ReverseArchiveButton } from "./(buttons)/ReverseArchiveButton";
+import { Archive } from "lucide-react";
 
 const FormHeader = lazy(() => import("@/app/dashboard/[id]/(forms)/FormHeader"));
 const PCK = lazy(() => import("@/app/dashboard/[id]/(forms)/PCK"));
@@ -106,13 +107,25 @@ async function Home(props: { params: Promise<{ id: string }> }) {
 
     return (
         <Suspense fallback={<Loading />}>
-            <Typography
-                variant="h1"
-                as="p"
-                className="mb-8 hidden text-black print:block"
-            >
-                Unitech
-            </Typography>
+            <div className="mx-auto flex max-w-prose justify-between">
+                <Typography
+                    variant="h1"
+                    as="p"
+                    className="mb-8 hidden text-black print:block"
+                >
+                    Unitech
+                </Typography>
+                {currentOrder.archived && (
+                    <Typography
+                        variant="h1"
+                        as="p"
+                        className="mb-12 ml-auto mr-auto flex w-fit items-center gap-2 text-muted-foreground print:mr-0"
+                    >
+                        <Archive className="size-10 stroke-2" />
+                        Archivováno
+                    </Typography>
+                )}
+            </div>
             {orderHeader ?
                 <FormHeader
                     orderHeader={orderHeader}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,6 @@ const withSerwist = withSerwistInit({
 
 const nextConfig = {
     experimental: {
-        turbo: {},
         reactCompiler: true,
     },
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/lodash": "^4.17.12",
         "@types/node": "^22.8.1",
-        "@types/react": "npm:types-react@19.0.0-alpha.3",
+        "@types/react": "19.0.0-rc.1",
         "@types/react-dom": "npm:types-react-dom@19.0.0-alpha.3",
         "@types/react-signature-canvas": "^1.0.6",
         "drizzle-kit": "^0.26.2",


### PR DESCRIPTION
The changes in this commit add a new indicator to the order page that displays
whether the order has been archived or not. This is implemented by checking the
`archived` property of the `currentOrder` object and rendering a new Typography
component with an Archive icon if the order is archived.

The purpose of this change is to provide a clear visual indication to the user
that the order they are viewing has been archived, which can be useful for
understanding the order's status and history.