### PR TITLE
feat(order): add paid status to order

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -21,6 +21,7 @@
     "importOrderSeparation": true,
     "importOrder": [
         "react",
+        "next/(.*)$",
         "<THIRD_PARTY_MODULES>",
         "lucide-react",
 

--- a/app/dashboard/[id]/(buttons)/PaidButton.tsx
+++ b/app/dashboard/[id]/(buttons)/PaidButton.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Coins, CreditCard, Wallet } from "lucide-react";
+
+import { updateOrderPaidStatus } from "@/db/db";
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+import { TPaid } from "@/types/dbSchemas";
+
+function PaidButton({ orderId, paid }: { orderId: string; paid: TPaid }) {
+    async function changeStatusAndReload(type: TPaid) {
+        await updateOrderPaidStatus(orderId, type).then(() => window.location.reload());
+    }
+
+    return (
+        <AlertDialog>
+            <AlertDialogTrigger
+                className="h-fit"
+                asChild
+            >
+                <Button
+                    variant={"outline"}
+                    className="flex gap-2 items-center h-10"
+                >
+                    {paid === "card" && <CreditCard className="size-4" />}
+                    {paid === "cash" && <Coins className="size-4" />}
+                    {paid === "unpaid" && <Wallet className="size-4" />}
+                    {paid === "unpaid" ? "Nezaplaceno" : "Zaplaceno"}
+                    &nbsp;
+                    {paid === "card" && "kartou"}
+                    {paid === "cash" && "hotově"}
+                </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Zadejte status zaplacení</AlertDialogTitle>
+                </AlertDialogHeader>
+                <AlertDialogDescription>
+                    Zde můžete zadat stav zaplacení objednávky.
+                </AlertDialogDescription>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Zrušit</AlertDialogCancel>
+
+                    {paid !== "cash" && (
+                        <Button
+                            onClick={() => changeStatusAndReload("cash")}
+                            className="flex gap-2 items-center"
+                        >
+                            <Coins className="size-4" />
+                            Hotově
+                        </Button>
+                    )}
+                    {paid !== "card" && (
+                        <Button
+                            onClick={() => changeStatusAndReload("card")}
+                            className="flex gap-2 items-center"
+                        >
+                            <CreditCard className="size-4" />
+                            Kartou
+                        </Button>
+                    )}
+                    {paid !== "unpaid" && (
+                        <Button
+                            onClick={() => changeStatusAndReload("unpaid")}
+                            variant={"destructive"}
+                        >
+                            Nezaplaceno
+                        </Button>
+                    )}
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}
+
+export { PaidButton };

--- a/app/dashboard/[id]/(forms)/PCK.tsx
+++ b/app/dashboard/[id]/(forms)/PCK.tsx
@@ -1487,13 +1487,16 @@ function PCK({ orderNewPCK, userRole, referenceDate, archived }: TPCKProps) {
 
                     <Separator />
 
-                    <Typography>
+                    <Typography
+                        as="h3"
+                        asChild
+                    >
                         <Unit
                             value={calculateTotalPrice().toFixed(2)}
                             unit=",-"
                             variant="h1"
                             as="p"
-                            className="text-right text-primary"
+                            className="text-right text-primary pt-12"
                         />
                     </Typography>
                 </form>

--- a/app/dashboard/[id]/page.tsx
+++ b/app/dashboard/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Archive } from "lucide-react";
+import { Archive, Coins, CreditCard } from "lucide-react";
 import React, { Suspense, lazy } from "react";
 
 import { validateSession } from "@/auth";
@@ -21,8 +21,8 @@ import { Separator } from "@/components/ui/separator";
 import { ArchiveButton } from "@/app/dashboard/[id]/(buttons)/ArchiveButton";
 import { DeleteOrderButton } from "@/app/dashboard/[id]/(buttons)/DeteteOrderButton";
 import { NotFound } from "@/app/dashboard/[id]/NotFound";
-import Loading from "@/app/loading";
 
+import { PaidButton } from "./(buttons)/PaidButton";
 import { PrintButton } from "./(buttons)/PrintButton";
 import { ReverseArchiveButton } from "./(buttons)/ReverseArchiveButton";
 
@@ -108,7 +108,7 @@ async function Home(props: { params: Promise<{ id: string }> }) {
     }
 
     return (
-        <Suspense fallback={<Loading />}>
+        <>
             <div className="mx-auto flex max-w-prose justify-between">
                 <Typography
                     variant="h1"
@@ -128,6 +128,18 @@ async function Home(props: { params: Promise<{ id: string }> }) {
                     </Typography>
                 )}
             </div>
+            {currentOrder.paid !== "unpaid" && (
+                <Typography
+                    variant="h1"
+                    as="p"
+                    className="mb-12 ml-auto mr-auto flex w-fit items-center gap-2 text-muted-foreground print:mr-0"
+                >
+                    {currentOrder.paid === "card" && <CreditCard className="size-10 stroke-2" />}
+                    {currentOrder.paid === "cash" && <Coins className="size-10 stroke-2" />}
+                    Zaplaceno {currentOrder.paid === "card" && "kartou"}
+                    {currentOrder.paid === "cash" && "hotově"}
+                </Typography>
+            )}
             {orderHeader ?
                 <FormHeader
                     orderHeader={orderHeader}
@@ -135,11 +147,6 @@ async function Home(props: { params: Promise<{ id: string }> }) {
                     archived={currentOrder.archived ?? true}
                 />
             :   <div>Nastala chyba při načítání objednávky. Zkuste to prosím znovu.</div>}
-
-            {/* <OrderFormWithNoSSR
-                order={currentOrder}
-                userRole={userRole}
-            /> */}
 
             <Separator className="my-16" />
 
@@ -171,8 +178,12 @@ async function Home(props: { params: Promise<{ id: string }> }) {
                 {currentOrder.archived ?
                     userRole && <ReverseArchiveButton currentOrder={currentOrder} />
                 :   <ArchiveButton currentOrder={currentOrder} />}
+                <PaidButton
+                    orderId={currentOrder.id ?? ""}
+                    paid={currentOrder.paid ?? "unpaid"}
+                />
             </div>
-        </Suspense>
+        </>
     );
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -71,6 +71,7 @@ export default async function RootLayout({
                 <ThemeProvider
                     attribute="class"
                     defaultTheme="light"
+                    disableTransitionOnChange
                 >
                     {children}
 

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -2,9 +2,14 @@
 
 import * as React from "react";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import dynamic from "next/dynamic";
+
 import { type ThemeProviderProps } from "next-themes/dist/types";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps): React.JSX.Element {
+const NextThemesProvider = dynamic(() => import("next-themes").then((e) => e.ThemeProvider), {
+    ssr: false,
+});
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
     return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }

--- a/db/db.ts
+++ b/db/db.ts
@@ -25,6 +25,7 @@ import type {
     TOrderNewPCK,
     TOrderPP2,
     TOrderPP2Specifications,
+    TPaid,
     TUser,
 } from "@/types/dbSchemas";
 
@@ -289,6 +290,10 @@ export async function updateOrderHeader(
         .execute();
 }
 
+export async function updateOrderPaidStatus(orderId: string, paid: TPaid) {
+    await db.update(order).set({ paid }).where(eq(order.id, orderId));
+}
+
 export async function updateOrderNewPCK(
     orderNewPCKId: string,
     content: TOrderNewPCK,
@@ -327,72 +332,6 @@ export async function updateOrderList1(
         .where(eq(OrderListOne.id, orderList1Id))
         .execute();
 }
-
-// export async function updateOrder(content: TOrder, role: boolean) {
-//     return await db
-//         .update(order)
-//         .set(
-//             role ? content : (
-//                 {
-//                     name: content.name,
-//                     signature: content.signature,
-//                     address: content.address,
-//                     phone: content.phone,
-//                     email: content.email,
-//                     dueDate: content.dueDate,
-//                     orderNumber: content.orderNumber,
-//                     ikeaNumber: content.ikeaNumber,
-//                     tax: content.tax,
-//                     bail: content.bail,
-
-//                     anotherService: content.anotherService,
-//                     timeToFinish: content.timeToFinish,
-//                     contactWithIkea: content.contactWithIkea,
-//                     numOfReturn: content.numOfReturn,
-//                     canceled: content.canceled,
-//                     reasonOfCancelation: content.reasonOfCancelation,
-//                     reasonOfImposibility: content.reasonOfImposibility,
-//                     waterConnection: content.waterConnection,
-//                     couplingsAndKitchenAdjustment: content.couplingsAndKitchenAdjustment,
-//                     testDishwasherFaucet: content.testDishwasherFaucet,
-//                     viewCutsOk: content.viewCutsOk,
-//                     electricalAppliancesPluggedIn: content.electricalAppliancesPluggedIn,
-//                     cleaningOfKitchenInstallationArea: content.cleaningOfKitchenInstallationArea,
-//                     electricalTestAppliances: content.electricalTestAppliances,
-//                     previousDamageToApartment: content.previousDamageToApartment,
-//                     sealingOfWorktops: content.sealingOfWorktops,
-//                     damageToFlatDuringInstallation: content.damageToFlatDuringInstallation,
-//                     comment: content.comment,
-
-//                     applianceOutsideOfIkea: content.applianceOutsideOfIkea,
-//                     gasApplianceOutsideOfIkea: content.gasApplianceOutsideOfIkea,
-//                     shipmentZoneOne: content.shipmentZoneOne,
-//                     shipmentZoneTwo: content.shipmentZoneTwo,
-//                     shipmentZoneThree: content.shipmentZoneThree,
-//                     shipmentZoneFour: content.shipmentZoneFour,
-//                     completeInstallationLockers: content.completeInstallationLockers,
-//                     completeAtypical: content.completeAtypical,
-//                     basicLockers: content.basicLockers,
-//                     basicMilled: content.basicMilled,
-//                     basicAtypical: content.basicAtypical,
-//                     installationDigester: content.installationDigester,
-//                     installationHob: content.installationHob,
-//                     installationGasHob: content.installationGasHob,
-//                     installationLights: content.installationLights,
-//                     installationMicrowave: content.installationMicrowave,
-//                     installationFreezer: content.installationFreezer,
-//                     installationDishwasher: content.installationDishwasher,
-//                     installationOven: content.installationOven,
-//                     installationSink: content.installationSink,
-//                     installationMilledJoint: content.installationMilledJoint,
-//                     installationWorktop: content.installationWorktop,
-//                     installationWallPanel: content.installationWallPanel,
-//                 }
-//             ),
-//         )
-//         .where(eq(order.id, content.id ?? ""))
-//         .returning();
-// }
 
 // . ||--------------------------------------------------------------------------------||
 // . ||                                  Create Order                                  ||

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -12,10 +12,13 @@ import {
     uuid,
 } from "drizzle-orm/pg-core";
 
+export const PaidStatus = pgEnum("paid_status", ["card", "cash", "unpaid"]);
+
 export const order = pgTable("order", {
     id: uuid("id").unique().notNull().defaultRandom().primaryKey(),
     referenceDate: timestamp("reference_date").notNull().default(new Date()),
     archived: boolean("archived").default(false),
+    paid: PaidStatus("paid").default("unpaid"),
 
     orderHeader: uuid("order_header")
         .notNull()

--- a/types/dbSchemas.ts
+++ b/types/dbSchemas.ts
@@ -2,6 +2,8 @@ import { order, User, OrderHeader, OrderNewPCK, OrderPP2, OrderListOne } from "@
 
 export type TUser = typeof User.$inferInsert;
 
+export type TPaid = "cash" | "card" | "unpaid";
+
 export type TOrder = typeof order.$inferInsert;
 
 export type TOrderHeader = typeof OrderHeader.$inferInsert;


### PR DESCRIPTION
The changes in this commit introduce a new paid status to the order schema, allowing for tracking the payment method of each order. This includes adding a new `paid` column to the `order` table in the database, as well as creating a new `PaidStatus` enum to represent the different payment statuses: `card`, `cash`, and `unpaid`.

Additionally, a new `PaidButton` component has been added to the dashboard page, which allows users to easily update the payment status of an order. This component uses an `AlertDialog` to present the user with options to mark the order as paid by card, paid by cash, or unpaid.

These changes provide more detailed information about the payment status of each order, which can be useful for tracking and reporting on the business's financial status.